### PR TITLE
fix(CI): fix SonarQube branch coverage exclusion command

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -171,5 +171,6 @@ jobs:
       # Upload the various reports to sonar
       - name: Upload report to SonarCloud
         env:
-          {{ gradlew sonar --parallel --build-cache -Dsonar.coverage.exclusionsOnCoverageTypeKEN }}
-        run: ./gradlew sonar --parallel --build-cache -Dsonar.coverage.exclusionsOnCoverageType=branch
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --parallel --build-cache -Dsonar.coverage.exclusionsOnCoverageType=branch ⁠


### PR DESCRIPTION
# Chore

Corrects a typo in the `android.yml` workflow file. The SonarQube command was fixed by changing `-Dsonar.coverage.exclusionsOnCoverageTypeKEN` to `-Dsonar.coverage.exclusionsOnCoverageType=branch` to ensure branch coverage exclusions are correctly applied.