### PR TITLE
refactor(navigation): change the app structure for m1

### DIFF
--- a/app/src/androidTest/java/com/android/swisstravel/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/android/swisstravel/ui/navigation/NavigationTest.kt
@@ -9,6 +9,7 @@ import com.android.swisstravel.utils.FirebaseEmulator
 import com.android.swisstravel.utils.SwissTravelTest
 import com.github.swent.swisstravel.SwissTravelApp
 import com.github.swent.swisstravel.ui.navigation.NavigationTestTags
+import com.github.swent.swisstravel.ui.theme.SwissTravelTheme
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -23,7 +24,7 @@ class NavigationTest : SwissTravelTest() {
     super.setUp()
     FirebaseEmulator.clearAuthEmulator()
     FirebaseEmulator.auth.signInAnonymously()
-    composeTestRule.setContent { SwissTravelApp() }
+    composeTestRule.setContent { SwissTravelTheme { SwissTravelApp() } }
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/swisstravel/utils/SwissTravelTest.kt
+++ b/app/src/androidTest/java/com/android/swisstravel/utils/SwissTravelTest.kt
@@ -94,15 +94,15 @@ abstract class SwissTravelTest {
   }
 
   fun ComposeTestRule.checkCurrentTripScreenIsDisplayed() {
-    onNodeWithTag(CurrentTripScreenTestTags.TEMPORARY_TEST_TAG)
+    onNodeWithTag(CurrentTripScreenTestTags.CREATE_TRIP_TEXT)
         .assertIsDisplayed()
-        .assertTextContains("Current Trip", substring = false, ignoreCase = true)
-    // TODO what defines the CurrentTrip that is different from others like the top bar
+        .assertTextContains("Create a trip", substring = false, ignoreCase = true)
+    onNodeWithTag(CurrentTripScreenTestTags.CREATE_TRIP_BUTTON).assertIsDisplayed()
   }
 
   fun ComposeTestRule.checkCurrentTripScreenIsNotDisplayed() {
-    onNodeWithTag(CurrentTripScreenTestTags.TEMPORARY_TEST_TAG).assertDoesNotExist()
-    // TODO Change this
+    onNodeWithTag(CurrentTripScreenTestTags.CREATE_TRIP_TEXT).assertDoesNotExist()
+    onNodeWithTag(CurrentTripScreenTestTags.CREATE_TRIP_BUTTON).assertDoesNotExist()
   }
 
   fun ComposeTestRule.checkDummyScreenIsDisplayed() {

--- a/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/CurrentTripScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/CurrentTripScreen.kt
@@ -1,27 +1,30 @@
 package com.github.swent.swisstravel.ui.currenttrip
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
 import com.github.swent.swisstravel.ui.navigation.BottomNavigationMenu
 import com.github.swent.swisstravel.ui.navigation.NavigationActions
 import com.github.swent.swisstravel.ui.navigation.NavigationTestTags
+import com.github.swent.swisstravel.ui.navigation.Screen
 import com.github.swent.swisstravel.ui.navigation.Tab
 
 object CurrentTripScreenTestTags {
-  // TODO remove when done implementing this screen and change the tests in NavigationTest
-  // accordingly
-  const val TEMPORARY_TEST_TAG = "temporaryTestTag"
-
-  /* Real test tags */
-
+  const val CREATE_TRIP_BUTTON = "createTripButton"
+  const val CREATE_TRIP_TEXT = "createTripText"
 }
 
 @Composable
@@ -35,11 +38,32 @@ fun CurrentTripScreen(navigationActions: NavigationActions? = null) {
             modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
       },
       content = { pd ->
-        Box(modifier = Modifier.fillMaxSize().padding(pd), contentAlignment = Alignment.Center) {
-          Text(
-              modifier = Modifier.testTag(CurrentTripScreenTestTags.TEMPORARY_TEST_TAG),
-              text = "Current Trip",
-              fontSize = 24.sp)
-        }
+        Column(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(pd)
+                    .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 4.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally) {
+              Text(
+                  text = "Create a trip",
+                  style = MaterialTheme.typography.displayLarge,
+                  color = MaterialTheme.colorScheme.onBackground,
+                  modifier = Modifier.testTag(CurrentTripScreenTestTags.CREATE_TRIP_TEXT))
+              Spacer(modifier = Modifier.height(72.dp))
+              // Create a new trip
+              Button(
+                  onClick = { navigationActions?.navigateTo(Screen.TripSettings1) },
+                  modifier =
+                      Modifier.testTag(CurrentTripScreenTestTags.CREATE_TRIP_BUTTON)
+                          .height(56.dp)
+                          .width(240.dp)) {
+                    Text(
+                        text = "Where are you starting?",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                  }
+            }
       })
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/map/MapLocationScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/map/MapLocationScreen.kt
@@ -14,10 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.github.swent.swisstravel.ui.navigation.BottomNavigationMenu
 import com.github.swent.swisstravel.ui.navigation.NavigationActions
-import com.github.swent.swisstravel.ui.navigation.NavigationTestTags
-import com.github.swent.swisstravel.ui.navigation.Tab
 import com.mapbox.maps.extension.compose.MapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
@@ -56,50 +53,41 @@ fun MapLocationScreen(
         viewModel.setPermissionGranted(isGranted)
       }
 
-  Scaffold(
-      bottomBar = {
-        BottomNavigationMenu(
-            selectedTab = Tab.Map,
-            onTabSelected = { tab -> navigationActions?.navigateTo(tab.destination) },
-            modifier = Modifier.testTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU))
-      }) { contentPadding ->
-        when {
-          isActivityNull -> {
-            Text(
-                "Error: unable to access the activity.",
-                modifier =
-                    Modifier.padding(contentPadding).testTag(MapLocationScreenTags.ERROR_TEXT))
-          }
-          !permissionGranted -> {
-            Column(modifier = Modifier.padding(contentPadding)) {
-              Text(
-                  "Location is required to display your position on the map.",
-                  modifier = Modifier.testTag(MapLocationScreenTags.PERMISSION_TEXT))
-              Button(
-                  onClick = { launcher.launch(android.Manifest.permission.ACCESS_FINE_LOCATION) },
-                  modifier = Modifier.testTag(MapLocationScreenTags.PERMISSION_BUTTON)) {
-                    Text("Allow location")
-                  }
-            }
-          }
-          else -> {
-            MapboxMap(
-                modifier =
-                    Modifier.fillMaxSize()
-                        .padding(contentPadding)
-                        .testTag(MapLocationScreenTags.MAP),
-                mapViewportState = mapViewportState) {
-                  MapEffect(Unit) { mapView ->
-                    mapView.location.updateSettings {
-                      locationPuck = createDefault2DPuck(withBearing = true)
-                      enabled = true
-                      puckBearing = PuckBearing.COURSE
-                      puckBearingEnabled = true
-                    }
-                    mapViewportState.transitionToFollowPuckState()
-                  }
-                }
-          }
+  Scaffold { contentPadding ->
+    when {
+      isActivityNull -> {
+        Text(
+            "Error: unable to access the activity.",
+            modifier = Modifier.padding(contentPadding).testTag(MapLocationScreenTags.ERROR_TEXT))
+      }
+      !permissionGranted -> {
+        Column(modifier = Modifier.padding(contentPadding)) {
+          Text(
+              "Location is required to display your position on the map.",
+              modifier = Modifier.testTag(MapLocationScreenTags.PERMISSION_TEXT))
+          Button(
+              onClick = { launcher.launch(android.Manifest.permission.ACCESS_FINE_LOCATION) },
+              modifier = Modifier.testTag(MapLocationScreenTags.PERMISSION_BUTTON)) {
+                Text("Allow location")
+              }
         }
       }
+      else -> {
+        MapboxMap(
+            modifier =
+                Modifier.fillMaxSize().padding(contentPadding).testTag(MapLocationScreenTags.MAP),
+            mapViewportState = mapViewportState) {
+              MapEffect(Unit) { mapView ->
+                mapView.location.updateSettings {
+                  locationPuck = createDefault2DPuck(withBearing = true)
+                  enabled = true
+                  puckBearing = PuckBearing.COURSE
+                  puckBearingEnabled = true
+                }
+                mapViewportState.transitionToFollowPuckState()
+              }
+            }
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Archive
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,7 +31,6 @@ import com.github.swent.swisstravel.model.trip.Trip
 import com.github.swent.swisstravel.ui.navigation.BottomNavigationMenu
 import com.github.swent.swisstravel.ui.navigation.NavigationActions
 import com.github.swent.swisstravel.ui.navigation.NavigationTestTags
-import com.github.swent.swisstravel.ui.navigation.Screen
 import com.github.swent.swisstravel.ui.navigation.Tab
 
 object MyTripsScreenTestTags {
@@ -42,7 +40,6 @@ object MyTripsScreenTestTags {
   const val UPCOMING_TRIPS_TITLE = "upcomingTripsTitle"
   const val UPCOMING_TRIPS = "upcomingTrips"
   const val EMPTY_UPCOMING_TRIPS_MSG = "emptyUpcomingTrips"
-  const val CREATE_TRIP_BUTTON = "createTripButton"
 
   fun getTestTagForTrip(trip: Trip): String = "trip${trip.uid}"
 }
@@ -125,15 +122,6 @@ fun MyTripsScreen(
                 modifier = Modifier.testTag(MyTripsScreenTestTags.EMPTY_CURRENT_TRIP_MSG))
           }
 
-          // Create a new trip
-          Spacer(modifier = Modifier.height(16.dp))
-
-          Button(
-              onClick = { navigationActions?.navigateTo(Screen.TripSettings1) },
-              modifier =
-                  Modifier.fillMaxWidth().testTag(MyTripsScreenTestTags.CREATE_TRIP_BUTTON)) {
-                Text("Create trip")
-              }
           // Upcoming Trip section
           Text(
               text = "Upcoming Trip",

--- a/app/src/main/java/com/github/swent/swisstravel/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/navigation/BottomNavigationMenu.kt
@@ -38,14 +38,10 @@ sealed class Tab(
       Tab("Current trip", Screen.CurrentTrip, Icons.Filled.LocationOn, Icons.Outlined.LocationOn)
 
   object Profile : Tab("Profile", Screen.Profile, Icons.Filled.Person, Icons.Outlined.Person)
-  // TODO Change this once there are new screens
-  // TODO Add test tags each time a new tab is added
-
-  object Map : Tab("Map", Screen.Map, Icons.Filled.LocationOn, Icons.Outlined.LocationOn)
 }
 
 /* List of all the tabs in the bottom bar */
-private val tabs = listOf(Tab.MyTrips, Tab.CurrentTrip, Tab.Profile, Tab.Map)
+private val tabs = listOf(Tab.MyTrips, Tab.CurrentTrip, Tab.Profile)
 
 /**
  * Composable setting up the bottom navigation bar

--- a/app/src/main/java/com/github/swent/swisstravel/ui/navigation/NavigationTestTags.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/navigation/NavigationTestTags.kt
@@ -7,13 +7,11 @@ object NavigationTestTags {
   const val PROFILE_TAB = "ProfileTab"
   const val MY_TRIPS_TAB = "MyTripsTab"
   const val CURRENT_TRIP_TAB = "CurrentTripTab"
-  const val MAP_TAB = "MapTab"
 
   fun getTestTag(tab: Tab): String =
       when (tab) {
         Tab.Profile -> PROFILE_TAB
         Tab.MyTrips -> MY_TRIPS_TAB
         Tab.CurrentTrip -> CURRENT_TRIP_TAB
-        Tab.Map -> MAP_TAB
       }
 }


### PR DESCRIPTION
This commit refactors the navigation and screen structure:

- Removes the "Map" tab from the bottom navigation bar, simplifying the main navigation to "My Trips", "Current Trip", and "Profile".
- Moves the "Create a new trip" button from the `MyTripsScreen` to the `CurrentTripScreen`.
- Updates the `CurrentTripScreen` to be a dedicated entry point for creating a new trip, prompting the user "Where are you starting?".
- Adjusts corresponding UI tests and test tags to reflect these changes, including wrapping the test app in `SwissTravelTheme`.