### PR TITLE
fix(trip-settings): fix traveler decrement button logic

### DIFF
--- a/app/src/androidTest/java/com/android/swisstravel/ui/composable/ComposableTests.kt
+++ b/app/src/androidTest/java/com/android/swisstravel/ui/composable/ComposableTests.kt
@@ -31,7 +31,8 @@ class ComposableTests {
           label = "test",
           count = count.value,
           onIncrement = { count.value++ },
-          onDecrement = { count.value-- })
+          onDecrement = { count.value-- },
+          enableButton = count.value > 0)
     }
     composeTestRule.onNodeWithTag("test" + CounterTestTags.COUNTER).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CounterTestTags.DECREMENT).performClick()

--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/counter.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/counter.kt
@@ -39,7 +39,13 @@ object CounterTestTags {
  * @param onDecrement Callback to be invoked when the decrement button is clicked.
  */
 @Composable
-fun Counter(label: String, count: Int, onIncrement: () -> Unit, onDecrement: () -> Unit) {
+fun Counter(
+    label: String,
+    count: Int,
+    onIncrement: () -> Unit,
+    onDecrement: () -> Unit,
+    enableButton: Boolean
+) {
   Column(
       modifier =
           Modifier.fillMaxWidth()
@@ -60,7 +66,7 @@ fun Counter(label: String, count: Int, onIncrement: () -> Unit, onDecrement: () 
               RoundIconButton(
                   text = "–",
                   onClick = onDecrement,
-                  enabled = count > 0,
+                  enabled = enableButton,
                   testTag = CounterTestTags.DECREMENT)
 
               Text(

--- a/app/src/main/java/com/github/swent/swisstravel/ui/tripSettings/tripTravelers.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/tripSettings/tripTravelers.kt
@@ -70,7 +70,8 @@ fun TripTravelersScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: 
                     onDecrement = {
                       if (travelers.adults > 1)
                           travelers = travelers.copy(adults = travelers.adults - 1)
-                    })
+                    },
+                    enableButton = travelers.adults > 1)
 
                 Spacer(modifier = Modifier.height(96.dp))
 
@@ -81,7 +82,8 @@ fun TripTravelersScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: 
                     onDecrement = {
                       if (travelers.children > 0)
                           travelers = travelers.copy(children = travelers.children - 1)
-                    })
+                    },
+                    enableButton = travelers.children > 0)
               }
 
               Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
The decrement button in the traveler counter is now correctly disabled based on the logic within the `tripTravelers` screen, rather than the counter composable itself.

- The `Counter` composable now accepts an `enableButton` parameter to control the enabled state of the decrement button externally.
- The `tripTravelers` screen is updated to pass the correct enabled state to each `Counter`, ensuring the "adults" counter cannot go below 1 and the "children" counter cannot go below 0.