### PR TITLE
chore(ci): decrease CI timeout

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,7 @@ jobs:
   bootcamp-ci:
     name: CI-SwissTravel
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     env:
       app_name: SwissTravelDebug
 


### PR DESCRIPTION
Decrease the timeout for the `bootcamp-ci` job in the Android workflow to 40 minutes.