### PR TITLE
feat(navigation): add top bar to trip creation screens

### DIFF
--- a/app/src/androidTest/java/com/android/swisstravel/ui/tripSettings/TripSettingsTests.kt
+++ b/app/src/androidTest/java/com/android/swisstravel/ui/tripSettings/TripSettingsTests.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.swisstravel.ui.mytrips.FakeTripsRepository
 import com.android.swisstravel.ui.profile.FakeUserRepository
+import com.android.swisstravel.utils.SwissTravelTest
 import com.github.swent.swisstravel.model.user.Preference
 import com.github.swent.swisstravel.ui.composable.PreferenceSelectorTestTags
 import com.github.swent.swisstravel.ui.composable.ToggleTestTags
@@ -23,7 +24,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 
-class TripSettingsTests {
+class TripSettingsTests : SwissTravelTest() {
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -34,6 +35,7 @@ class TripSettingsTests {
   fun tripDateScreenTest() {
     composeTestRule.setContent { SwissTravelTheme { TripDateScreen(onNext = {}) } }
     composeTestRule.onNodeWithTag(TripDateTestTags.TRIP_DATE_SCREEN).assertExists()
+    composeTestRule.checkTopBarIsDisplayed()
     composeTestRule.onNodeWithTag(TripDateTestTags.NEXT).performClick()
   }
 
@@ -44,6 +46,7 @@ class TripSettingsTests {
     composeTestRule
         .onNodeWithTag(TripPreferencesTestTags.TRIP_PREFERENCES_TITLE)
         .assertIsDisplayed()
+    composeTestRule.checkTopBarIsDisplayed()
     /* Preference Selector */
     composeTestRule
         .onNodeWithTag(PreferenceSelectorTestTags.PREFERENCE_SELECTOR)
@@ -96,6 +99,7 @@ class TripSettingsTests {
   fun tripTravelersScreenTest() {
     composeTestRule.setContent { SwissTravelTheme { TripTravelersScreen(onNext = {}) } }
     composeTestRule.onNodeWithTag(TripTravelersTestTags.TRIP_TRAVELERS_SCREEN).assertExists()
+    composeTestRule.checkTopBarIsDisplayed()
     composeTestRule.onNodeWithTag(TripTravelersTestTags.NEXT).performClick()
   }
 }

--- a/app/src/androidTest/java/com/android/swisstravel/utils/SwissTravelTest.kt
+++ b/app/src/androidTest/java/com/android/swisstravel/utils/SwissTravelTest.kt
@@ -123,6 +123,11 @@ abstract class SwissTravelTest {
     onNodeWithTag(NavigationTestTags.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
   }
 
+  fun ComposeTestRule.checkTopBarIsDisplayed() {
+    onNodeWithTag(NavigationTestTags.TOP_BAR).assertIsDisplayed()
+    onNodeWithTag(NavigationTestTags.TOP_BAR_BUTTON).assertIsDisplayed()
+  }
+
   fun <A : ComponentActivity> AndroidComposeTestRule<ActivityScenarioRule<A>, A>
       .checkActivityStateOnPressBack(shouldFinish: Boolean) {
     activityRule.scenario.onActivity { activity ->

--- a/app/src/main/java/com/github/swent/swisstravel/MainActivity.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/MainActivity.kt
@@ -187,17 +187,20 @@ fun SwissTravelApp(
       composable(Screen.TripSettings1.route) {
         TripDateScreen(
             viewModel = tripSettingsViewModel(navController),
-            onNext = { navigationActions.navigateTo(Screen.TripSettings2) })
+            onNext = { navigationActions.navigateTo(Screen.TripSettings2) },
+            onPrevious = { navigationActions.goBack() })
       }
       composable(Screen.TripSettings2.route) {
         TripTravelersScreen(
             viewModel = tripSettingsViewModel(navController),
-            onNext = { navigationActions.navigateTo(Screen.TripSettings3) })
+            onNext = { navigationActions.navigateTo(Screen.TripSettings3) },
+            onPrevious = { navigationActions.goBack() })
       }
       composable(Screen.TripSettings3.route) {
         TripPreferencesScreen(
             viewModel = tripSettingsViewModel(navController),
-            onDone = { navigationActions.navigateTo(Screen.MyTrips) })
+            onDone = { navigationActions.navigateTo(Screen.MyTrips) },
+            onPrevious = { navigationActions.goBack() })
       }
     }
 

--- a/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripDate.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripDate.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.ui.composable.DateSelectorRow
+import com.github.swent.swisstravel.ui.navigation.TopBar
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.collectLatest
@@ -34,7 +35,11 @@ object TripDateTestTags {
  * @param onNext Callback to be invoked when the user wants to proceed to the next step.
  */
 @Composable
-fun TripDateScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: () -> Unit = {}) {
+fun TripDateScreen(
+    viewModel: TripSettingsViewModel = viewModel(),
+    onNext: () -> Unit = {},
+    onPrevious: () -> Unit = {}
+) {
   val tripSettings by viewModel.tripSettings.collectAsState()
   var startDate by remember { mutableStateOf(tripSettings.date.startDate ?: LocalDate.now()) }
   var endDate by remember {
@@ -90,58 +95,62 @@ fun TripDateScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: () ->
   LaunchedEffect(endDate) {
     endDatePicker.updateDate(endDate.year, endDate.monthValue - 1, endDate.dayOfMonth)
   }
+  Scaffold(
+      topBar = { TopBar(onClick = { onPrevious() }) },
+      modifier = Modifier.testTag(TripDateTestTags.TRIP_DATE_SCREEN),
+  ) { pd ->
+    Surface(
+        modifier = Modifier.fillMaxSize().padding(pd),
+        color = MaterialTheme.colorScheme.background) {
+          Column(
+              modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.SpaceBetween) {
 
-  Surface(
-      modifier = Modifier.fillMaxSize().testTag(TripDateTestTags.TRIP_DATE_SCREEN),
-      color = MaterialTheme.colorScheme.background) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween) {
+                // --- Title ---
+                Text(
+                    text = stringResource(R.string.trip_dates),
+                    textAlign = TextAlign.Center,
+                    style =
+                        MaterialTheme.typography.headlineMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onBackground))
 
-              // --- Title ---
-              Text(
-                  text = stringResource(R.string.trip_dates),
-                  textAlign = TextAlign.Center,
-                  style =
-                      MaterialTheme.typography.headlineMedium.copy(
-                          fontWeight = FontWeight.Bold,
-                          color = MaterialTheme.colorScheme.onBackground))
+                Spacer(modifier = Modifier.height(32.dp))
 
-              Spacer(modifier = Modifier.height(32.dp))
+                // --- Date selectors ---
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally) {
+                      DateSelectorRow(
+                          label = stringResource(R.string.start_date),
+                          dateText = startDate.format(formatter),
+                          onClick = { startDatePicker.show() })
 
-              // --- Date selectors ---
-              Column(
-                  modifier = Modifier.fillMaxWidth(),
-                  horizontalAlignment = Alignment.CenterHorizontally) {
-                    DateSelectorRow(
-                        label = stringResource(R.string.start_date),
-                        dateText = startDate.format(formatter),
-                        onClick = { startDatePicker.show() })
+                      Spacer(modifier = Modifier.height(48.dp))
 
-                    Spacer(modifier = Modifier.height(48.dp))
+                      DateSelectorRow(
+                          label = stringResource(R.string.end_date),
+                          dateText = endDate.format(formatter),
+                          onClick = { endDatePicker.show() })
+                    }
 
-                    DateSelectorRow(
-                        label = stringResource(R.string.end_date),
-                        dateText = endDate.format(formatter),
-                        onClick = { endDatePicker.show() })
-                  }
+                Spacer(modifier = Modifier.height(16.dp))
 
-              Spacer(modifier = Modifier.height(16.dp))
-
-              // --- Done button ---
-              Button(
-                  onClick = { viewModel.onNextFromDateScreen() },
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.primary),
-                  shape = RoundedCornerShape(24.dp),
-                  modifier = Modifier.testTag(TripDateTestTags.NEXT)) {
-                    Text(
-                        text = stringResource(R.string.next),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.titleMedium)
-                  }
-            }
-      }
+                // --- Done button ---
+                Button(
+                    onClick = { viewModel.onNextFromDateScreen() },
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary),
+                    shape = RoundedCornerShape(24.dp),
+                    modifier = Modifier.testTag(TripDateTestTags.NEXT)) {
+                      Text(
+                          text = stringResource(R.string.next),
+                          color = MaterialTheme.colorScheme.onPrimary,
+                          style = MaterialTheme.typography.titleMedium)
+                    }
+              }
+        }
+  }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripPreferences.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripPreferences.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +30,7 @@ import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.model.user.Preference
 import com.github.swent.swisstravel.ui.composable.PreferenceSelector
 import com.github.swent.swisstravel.ui.composable.PreferenceToggle
+import com.github.swent.swisstravel.ui.navigation.TopBar
 import kotlinx.coroutines.flow.collectLatest
 
 /** Test tags for UI tests to identify components. */
@@ -45,7 +47,11 @@ object TripPreferencesTestTags {
  * @param onDone Callback to be invoked when the user is done setting preferences.
  */
 @Composable
-fun TripPreferencesScreen(viewModel: TripSettingsViewModel = viewModel(), onDone: () -> Unit = {}) {
+fun TripPreferencesScreen(
+    viewModel: TripSettingsViewModel = viewModel(),
+    onDone: () -> Unit = {},
+    onPrevious: () -> Unit = {}
+) {
   val tripSettings by viewModel.tripSettings.collectAsState()
   val prefs = tripSettings.preferences
   val context = LocalContext.current
@@ -68,55 +74,60 @@ fun TripPreferencesScreen(viewModel: TripSettingsViewModel = viewModel(), onDone
   }
 
   LaunchedEffect(prefs) { viewModel.updatePreferences(prefs) }
-
-  Surface(
+  Scaffold(
       modifier = Modifier.fillMaxSize().testTag(TripPreferencesTestTags.TRIP_PREFERENCES_SCREEN),
-      color = MaterialTheme.colorScheme.background) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween) {
-              Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      topBar = { TopBar(onClick = { onPrevious() }) }) { pd ->
+        Surface(
+            modifier = Modifier.fillMaxSize().padding(pd),
+            color = MaterialTheme.colorScheme.background) {
+              Column(
+                  modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 24.dp),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  verticalArrangement = Arrangement.SpaceBetween) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
 
-                // --- Title ---
-                Text(
-                    modifier = Modifier.testTag(TripPreferencesTestTags.TRIP_PREFERENCES_TITLE),
-                    text = stringResource(R.string.travelling_preferences),
-                    textAlign = TextAlign.Center,
-                    style =
-                        MaterialTheme.typography.headlineMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                        ))
+                      // --- Title ---
+                      Text(
+                          modifier =
+                              Modifier.testTag(TripPreferencesTestTags.TRIP_PREFERENCES_TITLE),
+                          text = stringResource(R.string.travelling_preferences),
+                          textAlign = TextAlign.Center,
+                          style =
+                              MaterialTheme.typography.headlineMedium.copy(
+                                  fontWeight = FontWeight.Bold,
+                              ))
 
-                Spacer(modifier = Modifier.height(32.dp))
+                      Spacer(modifier = Modifier.height(32.dp))
 
-                // --- Preferences ---
-                PreferenceSelector(
-                    isChecked = { pref -> prefs.contains(pref) },
-                    onCheckedChange = { preference ->
-                      viewModel.updatePreferences(prefs.toggle(preference))
-                    })
-                Spacer(modifier = Modifier.height(32.dp))
+                      // --- Preferences ---
+                      PreferenceSelector(
+                          isChecked = { pref -> prefs.contains(pref) },
+                          onCheckedChange = { preference ->
+                            viewModel.updatePreferences(prefs.toggle(preference))
+                          })
+                      Spacer(modifier = Modifier.height(32.dp))
 
-                PreferenceToggle(
-                    stringResource(R.string.handicapped_traveler),
-                    prefs.contains(Preference.WHEELCHAIR_ACCESSIBLE),
-                    onValueChange = { _ ->
-                      viewModel.updatePreferences(prefs.toggle(Preference.WHEELCHAIR_ACCESSIBLE))
-                    })
-              }
+                      PreferenceToggle(
+                          stringResource(R.string.handicapped_traveler),
+                          prefs.contains(Preference.WHEELCHAIR_ACCESSIBLE),
+                          onValueChange = { _ ->
+                            viewModel.updatePreferences(
+                                prefs.toggle(Preference.WHEELCHAIR_ACCESSIBLE))
+                          })
+                    }
 
-              // --- Done button ---
-              Button(
-                  onClick = { viewModel.saveTrip() },
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.primary),
-                  modifier = Modifier.testTag(TripPreferencesTestTags.DONE)) {
-                    Text(
-                        stringResource(R.string.done),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.titleMedium)
+                    // --- Done button ---
+                    Button(
+                        onClick = { viewModel.saveTrip() },
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary),
+                        modifier = Modifier.testTag(TripPreferencesTestTags.DONE)) {
+                          Text(
+                              stringResource(R.string.done),
+                              color = MaterialTheme.colorScheme.onPrimary,
+                              style = MaterialTheme.typography.titleMedium)
+                        }
                   }
             }
       }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripTravelers.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/tripcreation/TripTravelers.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.ui.composable.Counter
+import com.github.swent.swisstravel.ui.navigation.TopBar
 
 /** Test tags for UI tests to identify components. */
 object TripTravelersTestTags {
@@ -28,7 +29,11 @@ object TripTravelersTestTags {
  * @param onNext Callback to be invoked when the user proceeds to the next step.
  */
 @Composable
-fun TripTravelersScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: () -> Unit = {}) {
+fun TripTravelersScreen(
+    viewModel: TripSettingsViewModel = viewModel(),
+    onNext: () -> Unit = {},
+    onPrevious: () -> Unit = {}
+) {
   val tripSettings by viewModel.tripSettings.collectAsState()
   var travelers by remember { mutableStateOf(tripSettings.travelers) }
 
@@ -38,68 +43,75 @@ fun TripTravelersScreen(viewModel: TripSettingsViewModel = viewModel(), onNext: 
       viewModel.updateTravelers(travelers.adults, travelers.children)
     }
   }
-
-  Surface(
-      modifier = Modifier.fillMaxSize().testTag(TripTravelersTestTags.TRIP_TRAVELERS_SCREEN),
-      color = MaterialTheme.colorScheme.background) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween) {
-
-              // --- Title ---
-              Text(
-                  text = stringResource(R.string.nb_travelers),
-                  textAlign = TextAlign.Center,
-                  style =
-                      MaterialTheme.typography.headlineMedium.copy(
-                          fontWeight = FontWeight.Bold,
-                          color = MaterialTheme.colorScheme.onBackground))
-
-              Spacer(modifier = Modifier.height(16.dp))
-
-              // --- Travelers selectors ---
+  Scaffold(
+      modifier = Modifier.testTag(TripTravelersTestTags.TRIP_TRAVELERS_SCREEN),
+      topBar = { TopBar(onClick = { onPrevious() }) }) { pd ->
+        Surface(
+            modifier = Modifier.fillMaxSize().padding(pd),
+            color = MaterialTheme.colorScheme.background) {
               Column(
-                  modifier = Modifier.fillMaxWidth(),
-                  verticalArrangement = Arrangement.Center,
-              ) {
-                Counter(
-                    label = stringResource(R.string.nb_adults),
-                    count = travelers.adults,
-                    onIncrement = { travelers = travelers.copy(adults = travelers.adults + 1) },
-                    onDecrement = {
-                      if (travelers.adults > 1)
-                          travelers = travelers.copy(adults = travelers.adults - 1)
-                    },
-                    enableButton = travelers.adults > 1)
+                  modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
+                  horizontalAlignment = Alignment.CenterHorizontally,
+                  verticalArrangement = Arrangement.SpaceBetween) {
 
-                Spacer(modifier = Modifier.height(96.dp))
-
-                Counter(
-                    label = stringResource(R.string.nb_children),
-                    count = travelers.children,
-                    onIncrement = { travelers = travelers.copy(children = travelers.children + 1) },
-                    onDecrement = {
-                      if (travelers.children > 0)
-                          travelers = travelers.copy(children = travelers.children - 1)
-                    },
-                    enableButton = travelers.children > 0)
-              }
-
-              Spacer(modifier = Modifier.height(16.dp))
-
-              // --- Done button ---
-              Button(
-                  onClick = onNext,
-                  colors =
-                      ButtonDefaults.buttonColors(
-                          containerColor = MaterialTheme.colorScheme.primary),
-                  shape = RoundedCornerShape(24.dp),
-                  modifier = Modifier.testTag(TripTravelersTestTags.NEXT)) {
+                    // --- Title ---
                     Text(
-                        text = stringResource(R.string.next),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        style = MaterialTheme.typography.titleMedium)
+                        text = stringResource(R.string.nb_travelers),
+                        textAlign = TextAlign.Center,
+                        style =
+                            MaterialTheme.typography.headlineMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onBackground))
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // --- Travelers selectors ---
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.Center,
+                    ) {
+                      Counter(
+                          label = stringResource(R.string.nb_adults),
+                          count = travelers.adults,
+                          onIncrement = {
+                            travelers = travelers.copy(adults = travelers.adults + 1)
+                          },
+                          onDecrement = {
+                            if (travelers.adults > 1)
+                                travelers = travelers.copy(adults = travelers.adults - 1)
+                          },
+                          enableButton = travelers.adults > 1)
+
+                      Spacer(modifier = Modifier.height(96.dp))
+
+                      Counter(
+                          label = stringResource(R.string.nb_children),
+                          count = travelers.children,
+                          onIncrement = {
+                            travelers = travelers.copy(children = travelers.children + 1)
+                          },
+                          onDecrement = {
+                            if (travelers.children > 0)
+                                travelers = travelers.copy(children = travelers.children - 1)
+                          },
+                          enableButton = travelers.children > 0)
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // --- Done button ---
+                    Button(
+                        onClick = onNext,
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.primary),
+                        shape = RoundedCornerShape(24.dp),
+                        modifier = Modifier.testTag(TripTravelersTestTags.NEXT)) {
+                          Text(
+                              text = stringResource(R.string.next),
+                              color = MaterialTheme.colorScheme.onPrimary,
+                              style = MaterialTheme.typography.titleMedium)
+                        }
                   }
             }
       }


### PR DESCRIPTION
Adds a `TopBar` with a back button to the trip creation flow (`TripDate`, `TripTravelers`, and `TripPreferences` screens) to enable backward navigation without system back button.

- Add a `TopBar` to the screens that need it.
- Updating the screen composable signatures to accept an `onPrevious` callback and modify the navigation graph in `MainActivity` to pass the `goBack()` action to the new `onPrevious` parameter.
- Adding tests to verify the `TopBar` is displayed on each of these screens.