### PR TITLE
refactor(MyTrips): extract SortedTripList composable

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
@@ -1,0 +1,118 @@
+package com.github.swent.swisstravel.ui.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.github.swent.swisstravel.R
+import com.github.swent.swisstravel.model.trip.Trip
+import com.github.swent.swisstravel.ui.mytrips.MyTripsScreenTestTags
+import com.github.swent.swisstravel.ui.mytrips.TripElement
+import com.github.swent.swisstravel.ui.mytrips.TripSortType
+
+/**
+ * A composable that displays a sorted list of trips with a dropdown menu for sorting options.
+ *
+ * @param title The title of the trip list.
+ * @param trips The list of trips to display.
+ * @param onClickTripElement Callback when a trip element is clicked.
+ * @param onClickDropDownMenu Callback when a sorting option is selected from the dropdown menu.
+ * @param onLongPress Callback when a trip element is long-pressed.
+ * @param isSelected Function to determine if a trip is selected.
+ * @param isSelectionMode Whether the selection mode is active.
+ */
+@Composable
+fun SortedTripList(
+    title: String = "",
+    trips: List<Trip> = emptyList(),
+    onClickTripElement: (Trip?) -> Unit = {},
+    onClickDropDownMenu: (TripSortType) -> Unit = {},
+    onLongPress: (Trip?) -> Unit = {},
+    isSelected: (Trip) -> Boolean = { false },
+    isSelectionMode: Boolean = false,
+    titleTestTag: String,
+    lazyColumnTestTag: String,
+    emptyMessageTestTag: String
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(top = 26.dp, bottom = 10.dp),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.testTag(titleTestTag))
+
+        var expanded by remember { mutableStateOf(false) }
+
+        Box {
+          IconButton(
+              onClick = { expanded = !expanded },
+              modifier = Modifier.testTag(MyTripsScreenTestTags.SORT_DROPDOWN_MENU)) {
+                Icon(
+                    Icons.AutoMirrored.Filled.Sort,
+                    contentDescription = stringResource(R.string.sort))
+              }
+
+          DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            val sortOptions =
+                listOf(
+                    TripSortType.START_DATE_ASC to R.string.start_date_asc,
+                    TripSortType.START_DATE_DESC to R.string.start_date_desc,
+                    TripSortType.END_DATE_ASC to R.string.end_date_asc,
+                    TripSortType.END_DATE_DESC to R.string.end_date_desc,
+                    TripSortType.NAME_ASC to R.string.name_asc,
+                    TripSortType.NAME_DESC to R.string.name_desc)
+            sortOptions.forEach { (type, resId) ->
+              DropdownMenuItem(
+                  text = { Text(stringResource(resId)) },
+                  onClick = {
+                    onClickDropDownMenu(type)
+                    expanded = false
+                  })
+            }
+          }
+        }
+      }
+
+  if (trips.isNotEmpty()) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth().testTag(lazyColumnTestTag)) {
+          items(trips.size) { index ->
+            val trip = trips[index]
+            TripElement(
+                trip = trip,
+                onClick = { onClickTripElement(trip) },
+                onLongPress = { onLongPress(trip) },
+                isSelected = isSelected(trip),
+                isSelectionMode = isSelectionMode)
+          }
+        }
+  } else {
+    Text(
+        text = stringResource(R.string.no_upcoming_trip),
+        modifier = Modifier.testTag(emptyMessageTestTag))
+  }
+}

--- a/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreen.kt
@@ -2,18 +2,13 @@ package com.github.swent.swisstravel.ui.mytrips
 
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DeleteOutline
@@ -49,6 +44,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.model.trip.Trip
 import com.github.swent.swisstravel.ui.composable.DeleteTripsDialog
+import com.github.swent.swisstravel.ui.composable.SortedTripList
 import com.github.swent.swisstravel.ui.map.NavigationMapScreenTestTags
 import com.github.swent.swisstravel.ui.navigation.BottomNavigationMenu
 import com.github.swent.swisstravel.ui.navigation.NavigationActions
@@ -360,73 +356,95 @@ private fun UpcomingTripsSection(
     onEnterSelectionMode: () -> Unit,
     onSortSelected: (TripSortType) -> Unit
 ) {
-  Row(
-      modifier = Modifier.fillMaxWidth().padding(top = 26.dp, bottom = 10.dp),
-      horizontalArrangement = Arrangement.SpaceBetween,
-      verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = stringResource(R.string.upcoming_trip),
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.testTag(MyTripsScreenTestTags.UPCOMING_TRIPS_TITLE))
-
-        var expanded by remember { mutableStateOf(false) }
-
-        Box {
-          IconButton(
-              onClick = { expanded = !expanded },
-              modifier = Modifier.testTag(MyTripsScreenTestTags.SORT_DROPDOWN_MENU)) {
-                Icon(
-                    Icons.AutoMirrored.Filled.Sort,
-                    contentDescription = stringResource(R.string.sort))
-              }
-
-          DropdownMenu(
-              expanded = expanded,
-              onDismissRequest = { expanded = false },
-              modifier = Modifier.background(MaterialTheme.colorScheme.onPrimary)) {
-                val sortOptions =
-                    listOf(
-                        TripSortType.START_DATE_ASC to R.string.start_date_asc,
-                        TripSortType.START_DATE_DESC to R.string.start_date_desc,
-                        TripSortType.END_DATE_ASC to R.string.end_date_asc,
-                        TripSortType.END_DATE_DESC to R.string.end_date_desc,
-                        TripSortType.NAME_ASC to R.string.name_asc,
-                        TripSortType.NAME_DESC to R.string.name_desc)
-                sortOptions.forEach { (type, resId) ->
-                  DropdownMenuItem(
-                      text = { Text(stringResource(resId)) },
-                      onClick = {
-                        onSortSelected(type)
-                        expanded = false
-                      })
-                }
-              }
+  SortedTripList(
+      title = stringResource(R.string.upcoming_trip),
+      trips = trips,
+      onClickTripElement = {
+        it?.let { trip ->
+          if (uiState.isSelectionMode) onToggleSelection(trip) else onSelectTrip(trip.uid)
         }
-      }
-
-  if (trips.isNotEmpty()) {
-    LazyColumn(
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth().testTag(MyTripsScreenTestTags.UPCOMING_TRIPS)) {
-          items(trips.size) { index ->
-            val trip = trips[index]
-            TripElement(
-                trip = trip,
-                onClick = {
-                  if (uiState.isSelectionMode) onToggleSelection(trip) else onSelectTrip(trip.uid)
-                },
-                onLongPress = {
-                  onEnterSelectionMode()
-                  onToggleSelection(trip)
-                },
-                isSelected = trip in uiState.selectedTrips,
-                isSelectionMode = uiState.isSelectionMode)
-          }
+      },
+      onClickDropDownMenu = { type -> onSortSelected(type) },
+      onLongPress = {
+        it?.let { trip ->
+          onEnterSelectionMode()
+          onToggleSelection(trip)
         }
-  } else {
-    Text(
-        text = stringResource(R.string.no_upcoming_trip),
-        modifier = Modifier.testTag(MyTripsScreenTestTags.EMPTY_UPCOMING_TRIPS_MSG))
-  }
+      },
+      isSelected = { trip -> trip in uiState.selectedTrips },
+      isSelectionMode = uiState.isSelectionMode,
+      titleTestTag = MyTripsScreenTestTags.UPCOMING_TRIPS_TITLE,
+      lazyColumnTestTag = MyTripsScreenTestTags.UPCOMING_TRIPS,
+      emptyMessageTestTag = MyTripsScreenTestTags.EMPTY_UPCOMING_TRIPS_MSG)
+  // TODO delete this once the screen is completed in the CurrentTrip selection PR
+  //  Row(
+  //      modifier = Modifier.fillMaxWidth().padding(top = 26.dp, bottom = 10.dp),
+  //      horizontalArrangement = Arrangement.SpaceBetween,
+  //      verticalAlignment = Alignment.CenterVertically) {
+  //        Text(
+  //            text = stringResource(R.string.upcoming_trip),
+  //            style = MaterialTheme.typography.headlineLarge,
+  //            color = MaterialTheme.colorScheme.onBackground,
+  //            modifier = Modifier.testTag(MyTripsScreenTestTags.UPCOMING_TRIPS_TITLE))
+  //
+  //        var expanded by remember { mutableStateOf(false) }
+  //
+  //        Box {
+  //          IconButton(
+  //              onClick = { expanded = !expanded },
+  //              modifier = Modifier.testTag(MyTripsScreenTestTags.SORT_DROPDOWN_MENU)) {
+  //                Icon(
+  //                    Icons.AutoMirrored.Filled.Sort,
+  //                    contentDescription = stringResource(R.string.sort))
+  //              }
+  //
+  //          DropdownMenu(
+  //              expanded = expanded,
+  //              onDismissRequest = { expanded = false },
+  //              modifier = Modifier.background(MaterialTheme.colorScheme.onPrimary)) {
+  //                val sortOptions =
+  //                    listOf(
+  //                        TripSortType.START_DATE_ASC to R.string.start_date_asc,
+  //                        TripSortType.START_DATE_DESC to R.string.start_date_desc,
+  //                        TripSortType.END_DATE_ASC to R.string.end_date_asc,
+  //                        TripSortType.END_DATE_DESC to R.string.end_date_desc,
+  //                        TripSortType.NAME_ASC to R.string.name_asc,
+  //                        TripSortType.NAME_DESC to R.string.name_desc)
+  //                sortOptions.forEach { (type, resId) ->
+  //                  DropdownMenuItem(
+  //                      text = { Text(stringResource(resId)) },
+  //                      onClick = {
+  //                        onSortSelected(type)
+  //                        expanded = false
+  //                      })
+  //                }
+  //              }
+  //        }
+  //      }
+  //
+  //  if (trips.isNotEmpty()) {
+  //    LazyColumn(
+  //        verticalArrangement = Arrangement.spacedBy(12.dp),
+  //        modifier = Modifier.fillMaxWidth().testTag(MyTripsScreenTestTags.UPCOMING_TRIPS)) {
+  //          items(trips.size) { index ->
+  //            val trip = trips[index]
+  //            TripElement(
+  //                trip = trip,
+  //                onClick = {
+  //                  if (uiState.isSelectionMode) onToggleSelection(trip) else
+  // onSelectTrip(trip.uid)
+  //                },
+  //                onLongPress = {
+  //                  onEnterSelectionMode()
+  //                  onToggleSelection(trip)
+  //                },
+  //                isSelected = trip in uiState.selectedTrips,
+  //                isSelectionMode = uiState.isSelectionMode)
+  //          }
+  //        }
+  //  } else {
+  //    Text(
+  //        text = stringResource(R.string.no_upcoming_trip),
+  //        modifier = Modifier.testTag(MyTripsScreenTestTags.EMPTY_UPCOMING_TRIPS_MSG))
+  //  }
 }


### PR DESCRIPTION
Extracts the logic for displaying a list of trips with sorting options into a new reusable `SortedTripList` composable.

- Creates `SortedTripList.kt` to create the new composable.
- `MyTripsScreen` is updated to use this new `SortedTripList` for displaying the upcoming trips.
- The new composable is made generic by accepting test tags as parameters (maybe to change later).