### PR TITLE
hotfix(geocoding): Use injected LocationRepository in DestinationText…

### DIFF
--- a/app/src/androidTest/java/com/github/swent/swisstravel/ui/tripSettings/FirstDestinationsTest.kt
+++ b/app/src/androidTest/java/com/github/swent/swisstravel/ui/tripSettings/FirstDestinationsTest.kt
@@ -144,6 +144,6 @@ class FirstDestinationsTest {
     val expectedLocation = fakeLocationRepository.locations.first()
 
     assertEquals(1, finalDestinations.size)
-    assertEquals(expectedLocation.name, finalDestinations.first().name)
+    assertEquals(expectedLocation, finalDestinations.first())
   }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/geocoding/DestinationTextFieldViewModel.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/geocoding/DestinationTextFieldViewModel.kt
@@ -13,7 +13,7 @@ import com.github.swent.swisstravel.model.map.MySwitzerlandLocationRepository
  * fetching destination suggestions.
  */
 class DestinationTextFieldViewModel(locationRepository: LocationRepository) :
-    AddressTextFieldViewModel(MySwitzerlandLocationRepository())
+    AddressTextFieldViewModel(locationRepository)
 
 // The following code and description was done by chatGPT
 /**


### PR DESCRIPTION
## Hotfix
This pull request fixes the fact that the LocationRepository was not passed correctly in the viewModel, creating a new viewModel down the line and thus not mocking the services when building tests. This fix is very small but should make sure that tests keep working.