### PR TITLE
refactor(tests): Improve test clarity and fix SortedTripList test

### DIFF
--- a/app/src/androidTest/java/com/github/swent/swisstravel/ui/composable/ComposableTests.kt
+++ b/app/src/androidTest/java/com/github/swent/swisstravel/ui/composable/ComposableTests.kt
@@ -19,6 +19,7 @@ import com.github.swent.swisstravel.model.user.Preference
 import com.github.swent.swisstravel.model.user.PreferenceCategories
 import com.github.swent.swisstravel.ui.mytrips.TripElementTestTags
 import com.github.swent.swisstravel.ui.mytrips.TripSortType
+import com.github.swent.swisstravel.ui.theme.SwissTravelTheme
 import com.github.swent.swisstravel.utils.SwissTravelTest
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -57,7 +58,7 @@ class ComposableTests : SwissTravelTest() {
     }
     composeTestRule.onNodeWithTag("test" + DateSelectorTestTags.DATE_SELECTOR).assertIsDisplayed()
     composeTestRule.onNodeWithTag(DateSelectorTestTags.DATE).performClick()
-    assert(clicked.value)
+    assertTrue(clicked.value)
   }
 
   @Test
@@ -140,7 +141,7 @@ class ComposableTests : SwissTravelTest() {
     }
     composeTestRule.onNodeWithTag("test" + SwitchTestTags.SWITCH_CONTAINER).assertIsDisplayed()
     composeTestRule.onNodeWithTag(SwitchTestTags.SWITCH).performClick()
-    assert(checked.value)
+    assertTrue(checked.value)
   }
 
   @Test
@@ -151,9 +152,9 @@ class ComposableTests : SwissTravelTest() {
     }
     composeTestRule.onNodeWithTag("test" + ToggleTestTags.TOGGLE).assertIsDisplayed()
     composeTestRule.onNodeWithTag(ToggleTestTags.YES).performClick()
-    assert(value.value)
+    assertTrue(value.value)
     composeTestRule.onNodeWithTag(ToggleTestTags.NO).performClick()
-    assert(!value.value)
+    assertTrue(!value.value)
   }
 
   @Test
@@ -171,7 +172,7 @@ class ComposableTests : SwissTravelTest() {
     composeTestRule
         .onNodeWithTag(SortMenuTestTags.getTestTagSortOption(TripSortType.START_DATE_ASC))
         .performClick()
-    assert(selectedSortType == TripSortType.START_DATE_ASC)
+    assertTrue(selectedSortType == TripSortType.START_DATE_ASC)
   }
 
   @Test
@@ -207,16 +208,18 @@ class ComposableTests : SwissTravelTest() {
     var sortClicked = false
 
     composeTestRule.setContent {
-      SortedTripList(
-          title = "My Trips",
-          trips = tripList,
-          onClickTripElement = { clickedTrip = it },
-          onLongPress = { longPressedTrip = it },
-          onClickDropDownMenu = { sortClicked = true },
-          isSelectionMode = false)
+      SwissTravelTheme {
+        SortedTripList(
+            title = "My Trips",
+            trips = tripList,
+            onClickTripElement = { clickedTrip = it },
+            onLongPress = { longPressedTrip = it },
+            onClickDropDownMenu = { sortClicked = true },
+            isSelectionMode = false)
+      }
     }
 
-    composeTestRule.checkSortedTripListIsDisplayed()
+    composeTestRule.checkSortedTripListNotEmptyIsDisplayed()
     composeTestRule.onNodeWithTag(TripElementTestTags.getTestTagForTrip(trip1)).performClick()
     assertEquals(trip1, clickedTrip)
     composeTestRule.onNodeWithTag(TripElementTestTags.getTestTagForTrip(trip2)).performTouchInput {
@@ -224,13 +227,13 @@ class ComposableTests : SwissTravelTest() {
     }
     assertEquals(trip2, longPressedTrip)
     composeTestRule.onNodeWithTag(SortedTripListTestTags.SORT_DROPDOWN_MENU).performClick()
-    // For some reason it doesn't work because it can't find the node,
-    // Tried multiple things like changing the location of the test tag, changing the semantics
-    // and other things but nothing worked
-    //        composeTestRule.waitForIdle()
-    //
-    // composeTestRule.onNodeWithTag(SortedTripListTestTags.getTestTagSortOption(TripSortType.END_DATE_DESC)).performClick()
-    //        assert(sortClicked)
+
+    composeTestRule
+        .onNodeWithTag(
+            SortedTripListTestTags.getTestTagSortOption(TripSortType.END_DATE_DESC),
+            useUnmergedTree = true)
+        .performClick()
+    assertTrue(sortClicked)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreenTest.kt
+++ b/app/src/androidTest/java/com/github/swent/swisstravel/ui/mytrips/MyTripsScreenTest.kt
@@ -66,7 +66,7 @@ class MyTripsScreenEmulatorTest : SwissTravelTest() {
         .assertIsDisplayed()
 
     // Check upcoming trip
-    composeTestRule.checkSortedTripListIsDisplayed()
+    composeTestRule.checkSortedTripListNotEmptyIsDisplayed()
     composeTestRule
         .onNodeWithTag(MyTripsScreenTestTags.getTestTagForTrip(upcomingTrip))
         .assertIsDisplayed()

--- a/app/src/androidTest/java/com/github/swent/swisstravel/utils/SwissTravelTest.kt
+++ b/app/src/androidTest/java/com/github/swent/swisstravel/utils/SwissTravelTest.kt
@@ -177,10 +177,11 @@ abstract class SwissTravelTest {
     onNodeWithTag(NavigationTestTags.TOP_BAR_BUTTON).assertDoesNotExist()
   }
 
-  fun ComposeTestRule.checkSortedTripListIsDisplayed() {
+  fun ComposeTestRule.checkSortedTripListNotEmptyIsDisplayed() {
+    onNodeWithTag(SortedTripListTestTags.SORTED_TRIP_LIST).assertIsDisplayed()
     onNodeWithTag(SortedTripListTestTags.TITLE_BUTTON_ROW).assertIsDisplayed()
     onNodeWithTag(SortedTripListTestTags.SORT_DROPDOWN_MENU).assertIsDisplayed()
-    onNodeWithTag(SortedTripListTestTags.TITLE)
+    onNodeWithTag(SortedTripListTestTags.TITLE).assertIsDisplayed()
     onNodeWithTag(SortedTripListTestTags.TRIP_LIST).assertIsDisplayed()
   }
 

--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
@@ -1,6 +1,7 @@
 package com.github.swent.swisstravel.ui.composable
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -23,6 +24,7 @@ object SortedTripListTestTags {
   const val EMPTY_MESSAGE = TripListTestTags.EMPTY_MESSAGE
   const val SORT_DROPDOWN_MENU = SortMenuTestTags.SORT_DROPDOWN_MENU
   const val TITLE = "SortedTripListTitle"
+  const val SORTED_TRIP_LIST = "SortedTripList"
 
   fun getTestTagSortOption(type: TripSortType): String {
     return SortMenuTestTags.getTestTagSortOption(type)
@@ -52,27 +54,29 @@ fun SortedTripList(
     isSelectionMode: Boolean = false,
     emptyListString: String = ""
 ) {
-  Row(
-      modifier =
-          Modifier.fillMaxWidth()
-              .padding(top = 26.dp, bottom = 10.dp)
-              .testTag(SortedTripListTestTags.TITLE_BUTTON_ROW),
-      horizontalArrangement = Arrangement.SpaceBetween,
-      verticalAlignment = Alignment.CenterVertically) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.testTag(SortedTripListTestTags.TITLE))
+  Column(modifier = Modifier.fillMaxWidth().testTag(SortedTripListTestTags.SORTED_TRIP_LIST)) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(top = 26.dp, bottom = 10.dp)
+                .testTag(SortedTripListTestTags.TITLE_BUTTON_ROW),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically) {
+          Text(
+              text = title,
+              style = MaterialTheme.typography.headlineLarge,
+              color = MaterialTheme.colorScheme.onBackground,
+              modifier = Modifier.testTag(SortedTripListTestTags.TITLE))
 
-        SortMenu(onClickDropDownMenu = onClickDropDownMenu)
-      }
+          SortMenu(onClickDropDownMenu = onClickDropDownMenu)
+        }
 
-  TripList(
-      trips = trips,
-      onClickTripElement = onClickTripElement,
-      onLongPress = onLongPress,
-      isSelected = isSelected,
-      isSelectionMode = isSelectionMode,
-      emptyListString = emptyListString)
+    TripList(
+        trips = trips,
+        onClickTripElement = onClickTripElement,
+        onLongPress = onLongPress,
+        isSelected = isSelected,
+        isSelectionMode = isSelectionMode,
+        emptyListString = emptyListString)
+  }
 }


### PR DESCRIPTION
Refactored tests for better clarity and robustness.

- Replaced `assert()` with the more explicit `assertTrue()` in composable tests.
- Fixed a failing test in `ComposableTests` for the `SortedTripList` by enabling `useUnmergedTree` to correctly find the sort menu option.
- Wrapped the `SortedTripList` in `SwissTravelTheme` within its test to ensure proper theme application.
- Added a `Column` to `SortedTripList` and updated related test helper functions to improve testability with the new test tag that goes with it.