### PR TITLE
feat(ui): add check icon or no icon option for current trip in trip list

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/SortedTripList.kt
@@ -52,6 +52,7 @@ fun SortedTripList(
     onLongPress: (Trip?) -> Unit = {},
     isSelected: (Trip) -> Boolean = { false },
     isSelectionMode: Boolean = false,
+    noIconTripElement: Boolean = false,
     emptyListString: String = ""
 ) {
   Column(modifier = Modifier.fillMaxWidth().testTag(SortedTripListTestTags.SORTED_TRIP_LIST)) {
@@ -77,6 +78,7 @@ fun SortedTripList(
         onLongPress = onLongPress,
         isSelected = isSelected,
         isSelectionMode = isSelectionMode,
+        noIconTripElement = noIconTripElement,
         emptyListString = emptyListString)
   }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/TripList.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/TripList.kt
@@ -33,6 +33,7 @@ fun TripList(
     onLongPress: (Trip?) -> Unit = {},
     isSelected: (Trip) -> Boolean = { false },
     isSelectionMode: Boolean = false,
+    noIconTripElement: Boolean = false,
     emptyListString: String = "",
 ) {
   if (trips.isNotEmpty()) {
@@ -46,7 +47,8 @@ fun TripList(
                 onClick = { onClickTripElement(trip) },
                 onLongPress = { onLongPress(trip) },
                 isSelected = isSelected(trip),
-                isSelectionMode = isSelectionMode)
+                isSelectionMode = isSelectionMode,
+                noIcon = noIconTripElement)
           }
         }
   } else {

--- a/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/SetCurrentTripScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/SetCurrentTripScreen.kt
@@ -92,6 +92,7 @@ fun SetCurrentTripScreen(
               },
               isSelected = isSelected,
               isSelectionMode = false,
+              noIconTripElement = true,
               emptyListString = stringResource(R.string.no_upcoming_trips))
         }
       }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/TripElement.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/TripElement.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -67,6 +68,8 @@ object TripElementTestTags {
  * @param onLongPress Called when the element is long-pressed (e.g., to enter selection mode).
  * @param isSelected Whether the trip is currently selected.
  * @param isSelectionMode Whether the UI is currently in selection mode.
+ * @param noIcon If true, no icon is displayed when isSelected is false. Otherwise, shows a check
+ *   icon.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -75,7 +78,8 @@ fun TripElement(
     onClick: () -> Unit,
     onLongPress: () -> Unit = {},
     isSelected: Boolean = false,
-    isSelectionMode: Boolean = false
+    isSelectionMode: Boolean = false,
+    noIcon: Boolean = false
 ) {
   Card(
       modifier =
@@ -134,6 +138,15 @@ fun TripElement(
                                     if (isSelected) ToggleableState.On else ToggleableState.Off
                                 role = Role.Checkbox
                               })
+                }
+                if (noIcon) {
+                  if (isSelected) {
+                    Icon(
+                        Icons.Filled.Check,
+                        contentDescription = stringResource(R.string.current_trip_details),
+                        tint = MaterialTheme.colorScheme.primary)
+                  }
+                  /* Else display nothing */
                 } else {
                   // Arrow icon for normal (non-selection) mode
                   Icon(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
 
     <!-- Trips -->
     <string name="go_trip_details">Go to Trip details</string>
+    <string name="current_trip_details">This is the current trip</string>
     <plurals name="n_selected">
         <item quantity="one">%d selected</item>
         <item quantity="other">%d selected</item>


### PR DESCRIPTION
Adds a `noIconTripElement` parameter to `TripList`, `SortedTripList`, and `noIcon`for `TripElement` composables.

When this flag is enabled, a check icon is displayed next to the selected trip instead of the usual checkbox or arrow, indicating it is selected or nothing if it isn't. The default behavior remains unchanged.