### PR TITLE
feat(mytrips): reduce the load of setting the current trip as current

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsViewModel.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/mytrips/MyTripsViewModel.kt
@@ -63,6 +63,8 @@ class MyTripsViewModel(tripsRepository: TripsRepository = TripsRepositoryProvide
         // Get all trips to find the current one (if any)
         val trips = tripsRepository.getAllTrips()
         val previousCurrentTrip = trips.find { it.isCurrent() }
+        // If the selected trip is already the current one, do nothing
+        if (previousCurrentTrip == trip) return@launch
 
         // If there was a current trip, unset it
         previousCurrentTrip?.let { current ->


### PR DESCRIPTION
When making a trip the current one, check if it is already the current trip. If so, do nothing to avoid unnecessary database writes.