### PR TITLE
refactor(RouteSegment): remove distance and path from RouteSegment

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/algorithm/tripschedule/TripScheduler.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/algorithm/tripschedule/TripScheduler.kt
@@ -140,9 +140,7 @@ fun scheduleTrip(
           RouteSegment(
               from = locs[i],
               to = locs[i + 1],
-              distanceMeter = 0,
               durationMinutes = driveSec.toInt() / 60,
-              path = emptyList(),
               transportMode = TransportMode.BUS,
               startDate = segStart.toTs(),
               endDate = segEnd.toTs())

--- a/app/src/main/java/com/github/swent/swisstravel/model/trip/RouteSegment.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/model/trip/RouteSegment.kt
@@ -8,9 +8,7 @@ import kotlin.math.roundToInt
  *
  * @property from The starting location of the route segment.
  * @property to The ending location of the route segment.
- * @property distanceMeter The distance of the route segment in meters.
  * @property durationMinutes The duration of the route segment in minutes.
- * @property path The path of the route segment.
  * @property transportMode The transport mode of the route segment.
  * @property startDate The start date of the route segment.
  * @property endDate The end date of the route segment.
@@ -18,9 +16,7 @@ import kotlin.math.roundToInt
 data class RouteSegment(
     val from: Location,
     val to: Location,
-    val distanceMeter: Int,
     val durationMinutes: Int,
-    val path: List<Coordinate>?,
     val transportMode: TransportMode?,
     val startDate: Timestamp,
     val endDate: Timestamp
@@ -31,12 +27,5 @@ data class RouteSegment(
     val duration = durationMinutes / 60.0
     val roundedDuration = (duration * 100).roundToInt() / 100.0
     return roundedDuration
-  }
-
-  /** Returns the distance in km with two decimals. */
-  fun getDistanceKm(): Double {
-    val distance = distanceMeter / 1000.0
-    val roundedDistance = (distance * 100).roundToInt() / 100.0
-    return roundedDistance
   }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/model/trip/TransportMode.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/model/trip/TransportMode.kt
@@ -5,5 +5,6 @@ enum class TransportMode {
   TRAIN,
   BUS,
   TRAM,
+  CAR,
   UNKNOWN
 }

--- a/app/src/main/java/com/github/swent/swisstravel/model/trip/TripsRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/model/trip/TripsRepositoryFirestore.kt
@@ -153,11 +153,7 @@ class TripsRepositoryFirestore(
     val from = mapToLocation(fromMap) ?: return null
     val to = mapToLocation(toMap) ?: return null
 
-    val distanceMeter = (map["distanceMeter"] as? Number)?.toInt() ?: return null
     val durationMinutes = (map["durationMinutes"] as? Number)?.toInt() ?: return null
-
-    val pathList =
-        (map["path"] as? List<*>)?.mapNotNull { mapToCoordinate(it as Map<*, *>) } ?: emptyList()
 
     val transportMode =
         (map["transportMode"] as? String)?.let { TransportMode.valueOf(it) } ?: return null
@@ -165,8 +161,7 @@ class TripsRepositoryFirestore(
     val startDate = map["startDate"] as? Timestamp ?: return null
     val endDate = map["endDate"] as? Timestamp ?: return null
 
-    return RouteSegment(
-        from, to, distanceMeter, durationMinutes, pathList, transportMode, startDate, endDate)
+    return RouteSegment(from, to, durationMinutes, transportMode, startDate, endDate)
   }
 
   /**

--- a/app/src/test/java/com/github/swent/swisstravel/model/trip/RouteSegmentTest.kt
+++ b/app/src/test/java/com/github/swent/swisstravel/model/trip/RouteSegmentTest.kt
@@ -1,9 +1,5 @@
-package com.android.swisstravel.data.trips
+package com.github.swent.swisstravel.model.trip
 
-import com.github.swent.swisstravel.model.trip.Coordinate
-import com.github.swent.swisstravel.model.trip.Location
-import com.github.swent.swisstravel.model.trip.RouteSegment
-import com.github.swent.swisstravel.model.trip.TransportMode
 import com.google.firebase.Timestamp
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -25,9 +21,7 @@ class RouteSegmentTest {
       RouteSegment(
           from = from,
           to = to,
-          distanceMeter = 1500,
           durationMinutes = 30,
-          path = path,
           transportMode = mode,
           startDate = Timestamp.now(),
           endDate = Timestamp.now())
@@ -37,14 +31,11 @@ class RouteSegmentTest {
         RouteSegment(
             from = from,
             to = to,
-            distanceMeter = 1500,
             durationMinutes = 30,
-            path = path,
             transportMode = TransportMode.UNKNOWN,
             startDate = Timestamp.now(),
             endDate = Timestamp.now())
 
-    assertEquals(1.5, segment.getDistanceKm(), 0.0)
     assertEquals(0.5, segment.getDurationHours(), 0.0)
   }
 }

--- a/app/src/test/java/com/github/swent/swisstravel/model/trip/TripTest.kt
+++ b/app/src/test/java/com/github/swent/swisstravel/model/trip/TripTest.kt
@@ -4,7 +4,6 @@ import com.github.swent.swisstravel.model.trip.activity.Activity
 import com.google.firebase.Timestamp
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.kotlin.description
 
 class TripTest {
 
@@ -36,9 +35,7 @@ class TripTest {
           RouteSegment(
               from = listActivities[0].location,
               to = listActivities[1].location,
-              distanceMeter = 278000, // ~278 km
               durationMinutes = 140,
-              path = listOf(Coordinate(46.2074, 6.1551), Coordinate(47.3850, 8.5736)),
               transportMode = TransportMode.TRAIN,
               startDate = Timestamp(1734005400, 0), // 10:30 (30 min after Geneva activity)
               endDate = Timestamp(1734011400, 0) // 12:10
@@ -48,9 +45,7 @@ class TripTest {
           RouteSegment(
               from = listActivities[1].location,
               to = Location(name = "Lucerne Station", coordinate = Coordinate(47.0503, 8.3102)),
-              distanceMeter = 52000, // ~52 km
               durationMinutes = 45,
-              path = listOf(Coordinate(47.3850, 8.5736), Coordinate(47.0503, 8.3102)),
               transportMode = TransportMode.TRAIN,
               startDate = Timestamp(1734017400, 0), // 14:30 (after Zurich activity + 20 min pause)
               endDate = Timestamp(1734020100, 0) // 15:15
@@ -60,9 +55,7 @@ class TripTest {
           RouteSegment(
               from = Location(name = "Lucerne Station", coordinate = Coordinate(47.0503, 8.3102)),
               to = listActivities[2].location,
-              distanceMeter = 2200,
               durationMinutes = 20,
-              path = listOf(Coordinate(47.0503, 8.3102), Coordinate(47.0502, 8.3103)),
               transportMode = TransportMode.BUS,
               startDate = Timestamp(1734021900, 0), // 15:45 (after 30-min pause)
               endDate = Timestamp(1734023100, 0) // 16:05

--- a/app/src/test/java/com/github/swent/swisstravel/model/trip/TripsRepositoryMockTest.kt
+++ b/app/src/test/java/com/github/swent/swisstravel/model/trip/TripsRepositoryMockTest.kt
@@ -72,9 +72,7 @@ class TripsRepositoryFirestorePublicTest {
         mapOf(
             "from" to locationMap,
             "to" to locationMap,
-            "distanceMeter" to 100,
             "durationMinutes" to 10,
-            "path" to listOf(mapOf("latitude" to 3.0, "longitude" to 4.0)),
             "transportMode" to TransportMode.WALKING.name,
             "startDate" to Timestamp.now(),
             "endDate" to Timestamp.now())


### PR DESCRIPTION
**Summary:**  
This PR streamlines the `RouteSegment` model by removing unused distance and path data, removing unused code. It also introduces a new `CAR` transport mode for better trip categorization.

**Changes:**  
- Removed `distanceMeter` and `path` from `RouteSegment` data class.  
- Deleted the `getDistanceKm()` method from `RouteSegment`.  
- Updated `TripsRepositoryFirestore` to stop mapping `distanceMeter` and `path` from Firestore documents.  
- Adjusted `TripScheduler` to no longer set these properties when creating `RouteSegment` instances.  
- Updated related tests (`TripTest`, `RouteSegmentTest`, `TripsRepositoryMockTest`) to reflect the new `RouteSegment` structure.  
- Added `CAR` to the `TransportMode` enum.
