### PR TITLE
fix(current-trip): change create trip button text

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/CurrentTripScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/currenttrip/CurrentTripScreen.kt
@@ -74,7 +74,7 @@ fun CurrentTripScreen(
                     enabled = isLoggedIn,
                     modifier = Modifier.testTag(CurrentTripScreenTestTags.CREATE_TRIP_BUTTON)) {
                       Text(
-                          text = stringResource(R.string.where_starting),
+                          text = stringResource(R.string.when_travelling),
                           style = MaterialTheme.typography.titleMedium,
                           color = MaterialTheme.colorScheme.onPrimary,
                       )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
 
     <!-- Current trip -->
     <string name="create_trip">Create a trip</string>
-    <string name="where_starting">Where are you starting?</string>
+    <string name="when_travelling">When are you travelling?</string>
     <string name="log_in_to_display">You must be logged in to display a current trip a create one.</string>
 
     <!-- Geocoding -->


### PR DESCRIPTION
The string resource `where_starting` has been renamed to `when_travelling`, and its value changed from "Where are you starting?" to "When are you travelling?". This new string is now used on the button, making the call to action clearer for the user.