### PR TITLE
fix(algorithm) : Anchor arrival and departure locations in the algorithm

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/algorithm/orderlocations/OpenTsp.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/algorithm/orderlocations/OpenTsp.kt
@@ -55,7 +55,14 @@ class OpenTsp {
 
     // Add the end node
     route.add(end)
-
+    // A check to ensure all nodes are in the route if n > 1
+    if (n > 1 && route.size != n) {
+      // This case can happen if the graph is not fully connected,
+      // or if there's an issue with the filtering.
+      // Reconstruct the route to ensure all nodes are present.
+      val missingNodes = (0 until n).filterNot { route.contains(it) }
+      route.addAll(route.size - 1, missingNodes)
+    }
     return twoOpt(route, dist)
   }
 

--- a/app/src/main/java/com/github/swent/swisstravel/algorithm/orderlocations/OrderLocations.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/algorithm/orderlocations/OrderLocations.kt
@@ -82,9 +82,12 @@ fun orderLocations(
     }
 
     // Compute the shortest path between the start and end locations
-    val startIndex = unique.indexOf(start)
-    val endIndex = unique.indexOf(end)
-
+    val startIndex = unique.indexOfFirst { it.coordinate == start.coordinate }
+    val endIndex = unique.indexOfFirst { it.coordinate == end.coordinate }
+    if (startIndex == -1 || endIndex == -1) {
+      onResult(OrderedRoute(locations, -1.0, emptyList()))
+      return@getDurations
+    }
     val order =
         if (startIndex == endIndex) {
           val tsp = ClosedTsp()

--- a/app/src/main/java/com/github/swent/swisstravel/ui/trip/tripinfos/TripInfoScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/trip/tripinfos/TripInfoScreen.kt
@@ -121,8 +121,8 @@ fun TripInfoScreen(
     currentStepIndex = 0
 
     val unique = (ui.activities.map { it.location } + ui.locations).distinctBy { it.coordinate }
-    val start = unique.first()
-    val end = unique.last()
+    val start = ui.locations.first()
+    val end = ui.locations.last()
 
     orderLocations(context, unique, start, end) { ordered ->
       if (ordered.totalDuration < 0) {


### PR DESCRIPTION
## Fix
This piece of code should fix issue #245 , where the arrival and departure locations were not the first and last locations in the algorithm. This was caused by the wrong attributions of departure and arrival destinations in TripInfoScreen.