### PR TITLE
chore(ci): improve ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -153,14 +153,14 @@ jobs:
       - name: Run instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 36
+          api-level: 34
           target: google_apis
           arch: x86_64
           avd-name: github
           force-avd-creation: true
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
           disable-animations: true
-          script: ./gradlew connectedCheck --parallel --build-cache --console=plain
+          script: ./gradlew connectedCheck --parallel --build-cache
 
       # Upload the test results to the artifacts
       - name: Upload Test Results


### PR DESCRIPTION
# Chore

This PR improves the CI by caching the Firebase emulators installation to make it a tiny bit faster, changes the order of the steps to make instrumentation tests first

## Main changes
- Caching firebase emulator installation as the warning suggested
- Changes the order of the steps to make instrumentation tests first since this is where most problems lie.