### PR TITLE
fix(friends): auto-accept mutual friend requests

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/MainActivity.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/MainActivity.kt
@@ -658,7 +658,8 @@ private fun NavGraphBuilder.friendsListNavGraph(
           ProfileScreen(
               profileViewModel = ProfileViewModel(requestedUid = uid),
               onBack = { navigationActions.goBack() },
-              onSelectTrip = { navigationActions.navigateTo(Screen.TripInfo(it)) })
+              onSelectTrip = { navigationActions.navigateTo(Screen.TripInfo(it)) },
+              friendsViewModel = friendsViewModel(navController))
         }
   }
 }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/friends/FriendsViewModel.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/friends/FriendsViewModel.kt
@@ -157,6 +157,7 @@ class FriendsViewModel(private val userRepository: UserRepository = UserReposito
     viewModelScope.launch {
       try {
         userRepository.removeFriend(_uiState.value.currentUserUid, toUid)
+        refreshFriends()
       } catch (e: Exception) {
         _uiState.update { it.copy(errorMsg = "Error removing friend: ${e.message}") }
       }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/profile/ProfileScreen.kt
@@ -59,6 +59,7 @@ import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.model.trip.Trip
 import com.github.swent.swisstravel.model.user.UserStats
 import com.github.swent.swisstravel.ui.composable.TripList
+import com.github.swent.swisstravel.ui.friends.FriendsViewModel
 import com.github.swent.swisstravel.ui.navigation.NavigationTestTags
 
 /** Test tags for the profile screen. */
@@ -104,6 +105,7 @@ fun ProfileScreen(
     onSelectTrip: (String) -> Unit = {},
     onEditPinnedTrips: () -> Unit = {},
     onEditPinnedImages: () -> Unit = {},
+    friendsViewModel: FriendsViewModel = viewModel(),
 ) {
   val context = LocalContext.current
   val uiState by profileViewModel.uiState.collectAsState()
@@ -123,7 +125,7 @@ fun ProfileScreen(
     UnfriendDialog(
         friendName = uiState.name,
         onConfirm = {
-          profileViewModel.removeFriend(uiState.uid)
+          friendsViewModel.removeFriend(uiState.uid)
           showUnfriendConfirmation = false
           onBack()
         },

--- a/app/src/main/java/com/github/swent/swisstravel/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/profile/ProfileViewModel.kt
@@ -153,20 +153,4 @@ class ProfileViewModel(
   fun clearErrorMsg() {
     _uiState.update { it.copy(errorMsg = null) }
   }
-
-  /**
-   * Calls the repository to remove a friend.
-   *
-   * @param uid The UID of the user to remove.
-   */
-  fun removeFriend(uid: String) {
-    viewModelScope.launch {
-      try {
-        val userUid = userRepository.getCurrentUser().uid
-        userRepository.removeFriend(userUid, uid)
-      } catch (e: Exception) {
-        _uiState.update { it.copy(errorMsg = "Error removing friend: ${e.message}") }
-      }
-    }
-  }
 }


### PR DESCRIPTION
# Fix

## Summary
This PR fixes the bug that flips the friend request when requesting one to someone who had already sent it.

## Main changes
- When a user sends a friend request to someone who has already sent them a request, the friendship is now automatically accepted.
- The `removeFriend` logic has been moved from `ProfileViewModel` to `FriendsViewModel` to centralize friend management.
- The Profile screen now uses `FriendsViewModel` for the unfriend action.
- Added a test case in `UserRepositoryEmulatorTest` to verify the mutual friend request auto-acceptance.