### PR TITLE
feat(random): add travel style preferences to random trip.

### DIFF
--- a/app/src/androidTest/java/com/github/swent/swisstravel/ui/tripcreation/TripCreationTests.kt
+++ b/app/src/androidTest/java/com/github/swent/swisstravel/ui/tripcreation/TripCreationTests.kt
@@ -99,16 +99,18 @@ class TripCreationTests : InMemorySwissTravelTest() {
     val preferenceSelector =
         composeTestRule.onNodeWithTag(PreferenceSelectorTestTags.PREFERENCE_SELECTOR)
     preferenceSelector.assertIsDisplayed()
-    for (preference in PreferenceCategories.Category.ACCESSIBILITY.getPreferences()) {
-      val tag = PreferenceSelectorTestTags.getTestTagButton(preference)
-      preferenceSelector.performScrollToNode(hasTestTag(tag))
-      composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
-    }
+    val preferenceCategories =
+        listOf(
+            PreferenceCategories.Category.ACCESSIBILITY, PreferenceCategories.Category.TRAVEL_STYLE)
     for (category in PreferenceCategories.Category.values()) {
       for (preference in category.getPreferences()) {
-        if (preference.category() != PreferenceCategories.Category.ACCESSIBILITY) {
+        if (!preferenceCategories.contains(preference.category())) {
           val tag = PreferenceSelectorTestTags.getTestTagButton(preference)
           composeTestRule.onNodeWithTag(tag).assertDoesNotExist()
+        } else {
+          val tag = PreferenceSelectorTestTags.getTestTagButton(preference)
+          preferenceSelector.performScrollToNode(hasTestTag(tag))
+          composeTestRule.onNodeWithTag(tag).assertIsDisplayed()
         }
       }
     }

--- a/app/src/main/java/com/github/swent/swisstravel/ui/composable/PreferenceSelector.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/composable/PreferenceSelector.kt
@@ -144,7 +144,8 @@ fun PreferenceSelector(
 ) {
   val categoriesToShow =
       if (isRandomTrip) {
-        listOf(PreferenceCategories.Category.ACCESSIBILITY)
+        listOf(
+            PreferenceCategories.Category.TRAVEL_STYLE, PreferenceCategories.Category.ACCESSIBILITY)
       } else {
         PreferenceCategories.Category.values().toList()
       }


### PR DESCRIPTION
The "Travel Style" preference category is now displayed on the trip creation screen when generating a random trip. This allows users to select travel style preferences in addition to accessibility options.

The corresponding UI tests have been updated to verify that both the "Accessibility" and "Travel Style" preference buttons are visible, while other categories remain hidden for random trips.