### PR TITLE
feat(map): add GeoapifyLocationRepository skeleton

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,10 @@ android {
         // Open transport data
         val apiToken = props.getProperty("OPEN_TRANSPORT_DATA_TOKEN") ?: ""
         buildConfigField("String", "OPEN_TRANSPORT_DATA_TOKEN", "\"$apiToken\"")
+
+        // Geoapify
+        val geoapifyKey = props.getProperty("GEOAPIFY_API_KEY") ?: ""
+        buildConfigField("String", "GEOAPIFY_API_KEY", "\"$geoapifyKey\"")
     }
 
     buildTypes {

--- a/app/src/main/java/com/github/swent/swisstravel/model/map/GeoapifyLocationRepository.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/model/map/GeoapifyLocationRepository.kt
@@ -1,0 +1,19 @@
+package com.github.swent.swisstravel.model.map
+
+import com.github.swent.swisstravel.BuildConfig
+import com.github.swent.swisstravel.model.trip.Location
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import okhttp3.OkHttpClient
+
+class GeoapifyLocationRepository(
+    private val client: OkHttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val apiKey: String = BuildConfig.GEOAPIFY_API_KEY,
+    private val baseUrl: String = "https://api.geoapify.com/v1/geocode/autocomplete?apiKey=$apiKey"
+) : LocationRepository {
+
+  override suspend fun search(query: String): List<Location> {
+    TODO("Not yet implemented")
+  }
+}


### PR DESCRIPTION
A new `GeoapifyLocationRepository` class has been created. This repository will be used to fetch location data from the Geoapify API.

- The class includes a placeholder `search` function.
- The Geoapify API key is now configured in `app/build.gradle.kts` and accessed via `BuildConfig`.