### PR TITLE
fix(firestore): adjust trip security rules

### DIFF
--- a/firebase/firestore/firestore.rules
+++ b/firebase/firestore/firestore.rules
@@ -20,11 +20,10 @@ service cloud.firestore {
         allow create: if request.auth != null &&
               request.auth.uid == request.resource.data.ownerId;
 
-              allow get, update, delete: if request.auth.uid == resource.data.ownerId &&
+              allow update, delete: if request.auth.uid == resource.data.ownerId &&
               request.auth != null;
 
-              allow list : if request.auth != null &&
-                    resource.data.ownerId == request.auth.uid;
+              allow get, list : if request.auth != null;
     }
     match /durationCache/{entryId} {
           allow read, delete: if request.auth != null;


### PR DESCRIPTION
Previously, `get` and `list` operations were restricted to the owner of the trip. Now, `get` and `list` are permitted for any authenticated user, while `update` and `delete` operations remain restricted to the trip's owner. This enables features that require displaying trip information to users other than the creator.