### PR TITLE
feat(friends): disable add friend button when offline

### DIFF
--- a/app/src/main/java/com/github/swent/swisstravel/ui/friends/FriendsListScreen.kt
+++ b/app/src/main/java/com/github/swent/swisstravel/ui/friends/FriendsListScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.swent.swisstravel.R
 import com.github.swent.swisstravel.model.user.User
+import com.github.swent.swisstravel.utils.NetworkUtils
 
 object FriendsScreenTestTags {
   const val FRIENDS_LIST = "friendsList"
@@ -66,6 +67,7 @@ fun FriendsListScreen(
 ) {
   val context = LocalContext.current
   val uiState by friendsViewModel.uiState.collectAsState()
+  val isOnline = NetworkUtils.isOnline(context)
 
   var isSearching by rememberSaveable { mutableStateOf(false) }
   var searchQuery by rememberSaveable { mutableStateOf("") }
@@ -99,8 +101,16 @@ fun FriendsListScreen(
       },
       floatingActionButton = {
         FloatingActionButton(
-            onClick = onAddFriend,
-            containerColor = MaterialTheme.colorScheme.primary,
+            onClick = {
+              if (isOnline) {
+                onAddFriend()
+              } else {
+                Toast.makeText(
+                        context, context.getString(R.string.requires_internet), Toast.LENGTH_SHORT)
+                    .show()
+              }
+            },
+            containerColor = if (isOnline) MaterialTheme.colorScheme.primary else Color.LightGray,
             contentColor = MaterialTheme.colorScheme.onPrimary,
             modifier = Modifier.testTag(FriendsScreenTestTags.ADD_FRIEND_BUTTON)) {
               Icon(


### PR DESCRIPTION
## Summary
This PR disables the "Add Friend" button on the "Friends" Screen when the user is offline. This is to avoid potential issues caused by having no internet connection.

## Key Changes
- Import `NetworkUtils` in `FriendsListScreen`.
- Check network connectivity status.
- Disable the "Add Friend" Floating Action Button and show a toast message if the user is offline.
- Change the FAB container color to `LightGray` when offline.